### PR TITLE
Fix install script

### DIFF
--- a/install_all.sh
+++ b/install_all.sh
@@ -94,7 +94,7 @@ if [ $current -eq 1 ]; then
 else
     git clone -b v0.35.0  --depth 1 https://github.com/facebook/folly
     git clone -b v0.24.0  --depth 1 https://github.com/facebook/fbthrift
-    git clone -b v1.0 https://github.com/facebook/thpp
+    git clone https://github.com/facebook/thpp
     git clone -b v1.0 https://github.com/facebook/fblualib
 fi
 


### PR DESCRIPTION
`thpp v1.0` constains invalid URL for `gtest` in the build script.

```
+ echo 'Installing TH++'
Installing TH++
+ echo

+ cd /tmp/user/1000/fblualib-build.fnLJcm/thpp/thpp
+ ./build.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1582  100  1582    0     0   1822      0 --:--:-- --:--:-- --:--:--  1822
Invalid gtest-1.7.0.zip file
```